### PR TITLE
Noise Correction on timestep T 

### DIFF
--- a/src/diffusers/schedulers/scheduling_ddim.py
+++ b/src/diffusers/schedulers/scheduling_ddim.py
@@ -203,10 +203,10 @@ class DDIMScheduler(SchedulerMixin, ConfigMixin):
         if trained_betas is not None:
             self.betas = torch.tensor(trained_betas, dtype=torch.float32)
         elif beta_schedule == "linear":
-            self.betas = torch.linspace(beta_start, beta_end, num_train_timesteps, dtype=torch.float32)
+            self.betas = torch.linspace(beta_start, beta_end, num_train_timesteps+1, dtype=torch.float32)
         elif beta_schedule == "scaled_linear":
             # this schedule is very specific to the latent diffusion model.
-            self.betas = torch.linspace(beta_start**0.5, beta_end**0.5, num_train_timesteps, dtype=torch.float32) ** 2
+            self.betas = torch.linspace(beta_start**0.5, beta_end**0.5, num_train_timesteps+1, dtype=torch.float32) ** 2
         elif beta_schedule == "squaredcos_cap_v2":
             # Glide cosine schedule
             self.betas = betas_for_alpha_bar(num_train_timesteps)
@@ -331,7 +331,7 @@ class DDIMScheduler(SchedulerMixin, ConfigMixin):
             # creates integer timesteps by multiplying by ratio
             # casting to int to avoid issues when num_inference_step is power of 3
             timesteps = np.round(np.arange(self.config.num_train_timesteps, 0, -step_ratio)).astype(np.int64)
-            timesteps -= 1
+            # timesteps -= 1
         else:
             raise ValueError(
                 f"{self.config.timestep_spacing} is not supported. Please make sure to choose one of 'leading' or 'trailing'."
@@ -446,6 +446,11 @@ class DDIMScheduler(SchedulerMixin, ConfigMixin):
 
         # 7. compute x_t without "random noise" of formula (12) from https://arxiv.org/pdf/2010.02502.pdf
         prev_sample = alpha_prod_t_prev ** (0.5) * pred_original_sample + pred_sample_direction
+
+        # 8. compute e_theta with random noise for timestep T
+        if timestep == self.config.num_train_timesteps:
+            pred_sample_direction_T = (1 - alpha_prod_t_prev - std_dev_t**2) ** (0.5) * sample
+            prev_sample = alpha_prod_t_prev ** (0.5) * pred_original_sample + pred_sample_direction_T
 
         if eta > 0:
             if variance_noise is not None and generator is not None:


### PR DESCRIPTION
# What does this PR do?
Modifies the Scheduler, by treating t=T as a unique case and replacing e_theta with the true noise. 

Includes two changes -
1. treats t=T as a unique case and modifies the e_theta to be just noise
![Screenshot from 2024-06-04 04-33-10](https://github.com/ModelsLab/diffusers_plus_plus/assets/39147312/b8590460-cca8-40f3-90e2-76be339bb6d3)
2. making sure that the timestep includes the last time step t=T 

:memo:   _I've seen people setting it from [1 to T-1], I find [1-T] gives off better results_ 

Fixes # (issue)
#17 

### Results (might want to open it and look closely)
| No Changes | using `2` [1-T] | `1`+`2` [1-T] + Noise Corr | 
| ------------ | ------------ | ------------ |
|  ![image1717453699 065996_ddim_trailing_1000](https://github.com/ModelsLab/diffusers_plus_plus/assets/39147312/2d6e4489-d4f5-4f35-860b-a0275265e3ae) | ![image1717455355 1361704_ddim_trailing_1001](https://github.com/ModelsLab/diffusers_plus_plus/assets/39147312/261d12b9-859b-4c36-9ed4-7bf4b3dffc40) |  ![image1717454177 6668074_ddim_trailing_1001_noisecorr](https://github.com/ModelsLab/diffusers_plus_plus/assets/39147312/1f1ecb64-fbff-40fd-9017-bab82caea996) | 

| More Results | 
| -------------- |
| ![image1717397064 261791_ddim_trailing_1001_noisecorr](https://github.com/ModelsLab/diffusers_plus_plus/assets/39147312/82a476af-167f-41e1-9ae7-a3dde81daa69) |
| ![image1717397100 1391854_ddim_trailing_1001_noisecorr](https://github.com/ModelsLab/diffusers_plus_plus/assets/39147312/c209a01f-d7f4-409f-9f71-4bf338b32cb1) |

---
if the quality improvements are significant, should be done through all the schedulers 
- [ ] EulerDiscreteScheduler
